### PR TITLE
Remove unnecesary blank lines on command output

### DIFF
--- a/src/migrations.js
+++ b/src/migrations.js
@@ -108,7 +108,10 @@ const addMigration = (name, note, diff) => {
 const runCmd = (cmd, params, options, silent) => {
   let p = proc.spawnSync(cmd, params, options);
   if(silent !== true){
-    p.output.forEach(v => console.log(v ? v.toString() : ""));
+    let out = p.stdout.toString(),
+        err = p.stderr.toString();
+    if(out) console.log(out);
+    if(err) console.log(err);
   }
   if(p.status != 0){
     process.exit(p.status);


### PR DESCRIPTION
When doing `subzero migrations init` the output is like this:
```







Created sqitch.conf
Created sqitch.plan
Created deploy/
Created revert/
Created verify/



Created deploy/0000000001-initial.sql
Created revert/0000000001-initial.sql
Created verify/0000000001-initial.sql
Added "0000000001-initial" to sqitch.plan






```

With the PR now is like this:
```
Created sqitch.conf
Created sqitch.plan
Created deploy/
Created revert/
Created verify/

Created deploy/0000000001-initial.sql
Created revert/0000000001-initial.sql
Created verify/0000000001-initial.sql
Added "0000000001-initial" to sqitch.plan

```