### PR TITLE
add fullUnicode support

### DIFF
--- a/src/dashboard.jsx
+++ b/src/dashboard.jsx
@@ -302,7 +302,8 @@ class Dashboard extends Component {
 const screen = blessed.screen({
   autoPadding: true,
   smartCSR: true,
-  title: 'subZero devtools'
+  title: 'subZero devtools',
+  fullUnicode: true
 });
 
 const runDashboard = () => {


### PR DESCRIPTION
Allow for rendering of East Asian double-width characters, it may affect performance slightly according to the docs, but it's worthy for me to be able reading the logs in full.

ref: https://github.com/chjj/blessed#options-1
> fullUnicode - Allow for rendering of East Asian double-width characters, utf-16 surrogate pairs, and unicode combining characters. This allows you to display text above the basic multilingual plane. This is behind an option because it may affect performance slightly negatively. Without this option enabled, all double-width, surrogate pair, and combining characters will be replaced by '??', '?', '' respectively. (NOTE: iTerm2 cannot display combining characters properly. Blessed simply removes them from an element's content if iTerm2 is detected).
