### PR TITLE
Fix unsynced stdout/stderr on dashboard

### DIFF
--- a/src/dashboard.jsx
+++ b/src/dashboard.jsx
@@ -118,9 +118,8 @@ class Dashboard extends Component {
     const printer = key == 'db' ? printSQL : printLog;
     timestamp = timestamp ? timestamp : 0;
     if (containers[key].logProc) { containers[key].logProc.kill() }
-    containers[key].logProc = proc.spawn('docker',['logs', '--tail', 500, '--since', timestamp, '-f', containers[key].name]);
+    containers[key].logProc = proc.exec(`docker logs --tail 500 --since ${timestamp} -f ${containers[key].name} 2>&1`);
     containers[key].logProc.stdout.on('data', data => logger.log(printer(data)));
-    containers[key].logProc.stderr.on('data', data => logger.log(printer(data)));
   }
   selectContainer = (idx) => {
     const {activeContainer, containerOrder} = this.state;

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -77,7 +77,7 @@ const incrementMigrationNumber = () => fs.writeFileSync(MIGRATION_NUMBER_FILE, (
 const addMigration = (name, note, diff) => {
 
   if (!fs.existsSync(SQITCH_CONF) || !fs.statSync(SQITCH_CONF).isFile()){
-    console.log("\x1b[31mError:\x1b[0m the file '%s' does not exist", CONF);
+    console.log("\x1b[31mError:\x1b[0m the file '%s' does not exist", SQITCH_CONF);
     process.exit(0);
   }
   const migrationNumber = padNumber(getMigrationNumber(), 10);


### PR DESCRIPTION
Seems the `2>&1` works on windows as well https://stackoverflow.com/questions/1420965/redirect-windows-cmd-stdout-and-stderr-to-a-single-file.

So maybe the only disadvantage of replacing `spawn` with `exec` is that it has a 200k max buffer size by default. 