### PR TITLE
Fix `subzero migrations add` command

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -50,7 +50,7 @@ export const runCmd = (cmd, params, options = {}, silent = false, exit_on_error 
   return pr;
 }
 
-export const sqitchDeploy = url => runCmd(SQITCH_CMD, ["deploy", url], {cwd: MIGRATIONS_DIR})
+export const sqitchDeploy = url => runCmd(SQITCH_CMD, ["deploy", url], {cwd: MIGRATIONS_DIR}, false, true)
 
 export const fileExists = path => fs.existsSync(path) && fs.statSync(path).isFile();
 

--- a/src/env.js
+++ b/src/env.js
@@ -37,7 +37,7 @@ export const USE_DOCKER_IMAGE = process.env.USE_DOCKER_IMAGE || true;
 const LOCALHOST = 'localhost';
 export const DEV_DB_URI = process.env.DEV_DB_URI || `postgres://${SUPER_USER}:${SUPER_USER_PASSWORD}@${LOCALHOST}:${DB_PORT}/${DB_NAME}`
 export const PROD_DB_URI = process.env.PROD_DB_URI || `postgres://${SUPER_USER}:${SUPER_USER_PASSWORD}@${LOCALHOST}:5433/${DB_NAME}`
-const _IGNORE_ROLES = process.env.IGNORE_ROLES || `${SUPER_USER}, ${DB_USER}, ${DB_ANON_ROLE}, postgres`
+const _IGNORE_ROLES = process.env.IGNORE_ROLES || `${SUPER_USER}, ${DB_USER}, postgres`
 export const IGNORE_ROLES = _IGNORE_ROLES.split(',').map(s => s.trim());
 export const DOCKER_APP_DIR = '/src';
 export const DOCKER_IMAGE = process.env.DOCKER_IMAGE || 'subzerocloud/subzero-cli-tools'

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -136,7 +136,7 @@ const getTempPostgres = (sqlDir) => {
     "-e", `POSTGRES_USER=${SUPER_USER}`, 
     "-e", `POSTGRES_PASSWORD=${SUPER_USER_PASSWORD}`,
     "-v", `${sqlDir}:/docker-entrypoint-initdb.d`,
-    "postgres"
+    "postgres:9.6.6"
   ]);
 
   console.log('Waiting for it to load')


### PR DESCRIPTION
To reproduce do:
```bash
> subzero base-project
# choose 1
# in the project dir
> docker-compose up -d
> subzero migrations init
```
And then the following error is obtained when doing:
```bash
> subzero migrations add v2                                                                                                 
Starting temporary Postgre database                                                                                                                            
706b45ef5a351b9c5f290fc76cbd4323cf8cb0fd8ee1e90d61a1ebaaaf4a15c1                                                                                               
Waiting for it to load                                                                                                                                         
WARNING: enabling "trust" authentication for local connections                                                                                                 
You can change this by editing pg_hba.conf or using the option -A, or                                                                                          
--auth-local and --auth-host, the next time you run initdb.                                                                                                    
waiting for server to start....LOG:  could not bind IPv6 socket: Cannot assign requested address                                                               
HINT:  Is another postmaster already running on port 5432? If not, wait a few seconds and retry.                                                               
LOG:  database system was shut down at 2017-11-23 20:36:57 UTC                                                                                                 
LOG:  MultiXact member wraparound protections are now enabled                                                                                                  
LOG:  database system is ready to accept connections                                                                                                           
LOG:  autovacuum launcher started                                                                                                                              
 done                                                                                                                                                          
server started                                                                                                                                                 
CREATE DATABASE                                                                                                                                                
                                                                                                                                                               
CREATE ROLE


/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/0000000000-setup.sql
CREATE ROLE


/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/0000000001-initial.sql
SET
SET
SET
CREATE ROLE
CREATE ROLE
CREATE ROLE
ERROR:  role "authenticator" already exists
STATEMENT:  CREATE ROLE authenticator;
psql:/docker-entrypoint-initdb.d/0000000001-initial.sql:17: ERROR:  role "authenticator" already exists
Gave up on waiting for db. The last 30 lines of log are above.
```
Whole trace is gone when including the authenticator role in the initial migration file, this role was set to be ignored [here](https://github.com/subzerocloud/subzero-cli/commit/0ffb928edb4680b2e55d9f368a36ec7077cb97b1#diff-f8eaa788855a366fd50ed80be1f325e3R44)(no apparent reason why this was done).