### PR TITLE
Add missing import for resetDb

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -12,7 +12,7 @@ import {
   WATCH_PATTERNS
 } from './env.js';
 
-import {checkIsAppDir, dockerContainers, runWatcher} from './common.js';
+import {checkIsAppDir, dockerContainers, runWatcher, resetDb} from './common.js';
 
 
 const watcherReady = () => {


### PR DESCRIPTION
resetDb() was moved from watch.js into common.js, but watch.js depends on it: https://github.com/subzerocloud/subzero-cli/commit/8ff985115554312c8dee39e3cd74beb6dfe4d209#diff-6d5b72dc174c462326c503d84a608e3c