### PR TITLE
Fix filesystem watcher on Windows systems

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -12,7 +12,7 @@ let cfg = {
 
 if (fs.existsSync(cfg.path) && fs.statSync(cfg.path).isFile()) {
   config(cfg);//.env file vars added to process.env
-  process.env.ENV_FILE = resolve(cfg.path)
+  process.env.ENV_FILE = resolve(cfg.path).replace(/\\/g, '/');
   process.env.APP_DIR = dirname(process.env.ENV_FILE);
 }
 


### PR DESCRIPTION
- Resolve of .env file will produce a path with backslashes on windows
- Watch patterns are relative to app dir with forward slashes
- Combined patterns are mixed with backslash + forward slashes
- Chokidar will not match events with those patterns (see #668)
- Forward slashes are allowed as path separator on Windows in nodejs
- Fix: Make all paths always have forward slash as separators

Related issue: https://github.com/paulmillr/chokidar/issues/668