### PR TITLE
Fix bug in migrations init

### DIFF
--- a/src/migrations.js
+++ b/src/migrations.js
@@ -327,7 +327,7 @@ program
   .option("--debug", "Verbose output and leaves the temporary files (used to create the migration) in place")
   .option("--db-docker-image <image>", "DOcker image used for temp postgres")
   .description('Setup sqitch config and create the first migration')
-  .action((name, options) => { checkIsAppDir(); initMigrations(options.debug, options.dbDockerImage);});
+  .action((options) => { checkIsAppDir(); initMigrations(options.debug, options.dbDockerImage);});
 
 program
   .command('add <name>')


### PR DESCRIPTION
This resolves issue: https://github.com/subzerocloud/subzero-cli/issues/38

Before this fix running migrations init without any argument resulted
in options being undefined and the script throwing.