### PR TITLE
More robust detection of pg version

### DIFF
--- a/src/migrations.js
+++ b/src/migrations.js
@@ -318,9 +318,15 @@ const apgdiffToFile = (file1, file2, destFile) => {
 const getPgVersion = (dbUri) =>{
   const env = Object.create( process.env ),
         result = runCmd(PSQL_CMD, ['--quiet', '--tuples-only', '-c', 'show server_version', dbUri], { env: env }, true, false).stdout.toString().trim();
-  let pgVersion = '11.3';
+
+  if(result == ''){
+    console.log("WARNING: Couldn't determine Postgres version, defaulting to 11.3.")
+    return '11.3';
+  }
+
+  let pgVersion = result;
   if(result.indexOf(' ') !== -1){
-    pgVersion = result.substr(0, result.indexOf(' ')); 
+    pgVersion = result.substr(0, result.indexOf(' '));
   }
   return pgVersion;
 }


### PR DESCRIPTION
Steps to reproduce:

1. Run a pg 9.6 container
2. Execute `subzero migrations init`

Expected: Detects the pg version (9.6.x)
Actual: Defaults to 11.3

Example:

```
psql --tuples-only -c "show server_version" postgres://superuser:sup@localhost:5432/my_db`
9.6.15
```

`9.6.15` is not properly extracted.

This PR uses the full result as the db version if there are no spaces in the result of `show server_version`.

If the result is is a blank string, we still default to `11.3` but also emit a warning. IMO it would be better to abort the script, but I can't just exit from within an async method and don't have time to figure out where to catch the error (I don't do a lot of js).