### PR TITLE
Pass env-file vars to migration functions

### DIFF
--- a/src/migrations.js
+++ b/src/migrations.js
@@ -213,6 +213,7 @@ const getTempPostgres = async (sqlDir, debug, dbDockerImage) => {
           "-e", `DEVELOPMENT=${process.env.DEVELOPMENT}`,
           "-e", `JWT_SECRET=${process.env.JWT_SECRET}`,
           "-v", `${sqlDir}:/docker-entrypoint-initdb.d`,
+          "--env-file", `${APP_DIR}/.env`,
           pgDockerImage
         ]
   if(debug){


### PR DESCRIPTION
subzero-cli reads `SUPER_USER` and `DB_USER` from the environment so they can be used during setup.

I need to be able to pass in more strings to use in functions and to define roles. This PR makes all vars set in .env available to setup scripts.