### PR TITLE
Change to not overwrite APP_DIR if already set

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -13,7 +13,7 @@ let cfg = {
 if (fs.existsSync(cfg.path) && fs.statSync(cfg.path).isFile()) {
   config(cfg);//.env file vars added to process.env
   process.env.ENV_FILE = resolve(cfg.path).replace(/\\/g, '/');
-  process.env.APP_DIR = dirname(process.env.ENV_FILE);
+  process.env.APP_DIR = (process.env.APP_DIR && resolve(process.env.APP_DIR)) || dirname(process.env.ENV_FILE);
 }
 
 export const COMPOSE_PROJECT_NAME = process.env.COMPOSE_PROJECT_NAME;


### PR DESCRIPTION
This is a pull request for the issue below.

https://github.com/subzerocloud/subzero-cli/issues/63


Changed so that APP_DIR is not overwritten when the environment variable APP_DIR is set and the subzero command is executed.